### PR TITLE
Passphrese env

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Installation
   * installation will add `pyconcrete.pth` into your `site-packages` for execute `sitecustomize.py` under pyconcrete which will automatic import pyconcrete
 
 ### source
+* get python-dev lib ( example for ubuntu18.04 & python 3.7 )
+```sh
+$ apt install python3.7-dev
+```
+
 * get the pyconcrete source code
 ```sh
 $ git clone <pyconcrete repo> <pyconcre dir>

--- a/README.md
+++ b/README.md
@@ -33,19 +33,6 @@ Installation
   * same passphrase will generate the same secret key
   * installation will add `pyconcrete.pth` into your `site-packages` for execute `sitecustomize.py` under pyconcrete which will automatic import pyconcrete
 
-### pip
-```sh
-$ pip install pyconcrete
-```
-  > If you only execute `pip install` will not display any prompt(via stdout) from pyconcrete. 
-  > Installation will be `blocked` and `waiting for user input passphrase twice`.
-  > You must input passphrase for installation continuously.
-
-```sh
-$ pip install pyconcrete --egg --install-option="--passphrase=<your passphrase>"
-```
-  > pyconcrete installed as egg, if you want to uninstall pyconcrete will need to manually delete `pyconcrete.pth`.
-  
 ### source
 * get the pyconcrete source code
 ```sh
@@ -54,6 +41,7 @@ $ git clone <pyconcrete repo> <pyconcre dir>
 
 * install pyconcrete
 ```sh
+$ export PYCONCRETE_PASSPHRASE=your_passphrese
 $ python setup.py install
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -142,13 +142,7 @@ class CmdBase:
         self.manual_create_secrete_key_file = not os.path.exists(SECRET_HEADER_PATH)
         if self.manual_create_secrete_key_file:
             if not self.passphrase:
-                self.passphrase = input("please input the passphrase \nfor encrypt your python script (enter for default) : \n")
-                if len(self.passphrase) == 0:
-                    self.passphrase = DEFAULT_KEY
-                else:
-                    passphrase2 = input("please input again to confirm\n")
-                    if self.passphrase != passphrase2:
-                        raise Exception("Passphrase is different")
+                self.passphrase=os.getenv('PYCONCRETE_PASSPHRASE', DEFAULT_KEY)
 
             k, f = hash_key(self.passphrase.encode('utf8'))
             create_secret_key_header(k, f)


### PR DESCRIPTION
It is suggested to change the passphrase that is taken from the standard input to be taken from the environment variable.

Because error occurs in pip install.

It is also effective when installing in Dockerfile.