### PR TITLE
Replace url for download pip.py for 3.6 back-capability

### DIFF
--- a/example/django/Dockerfile
+++ b/example/django/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex \
         \
     && rm -rf /var/lib/apt/lists/* \
     \
-    && curl https://bootstrap.pypa.io/get-pip.py | python${PY_VER}
+    && curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | python${PY_VER}
 
 RUN set -ex \
     && mkdir -p /code \


### PR DESCRIPTION
#99 Resolves that issue