### PR TITLE
fix pyconcrete-exe doesn't handle correct return code when exception

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import subprocess
 import sys
 from os.path import abspath, dirname, join
@@ -33,6 +34,10 @@ class Venv:
         self.bin_dir = join(self.env_dir, 'bin')
         self.executable = join(self.bin_dir, 'python')
 
+    def raise_if_pyconcrete_not_installed(self):
+        if not os.path.exists(join(self.bin_dir, 'pyconcrete')):
+            raise Exception("pyconcrete not been installed yet, please make sure you setup pye_cli before use the venv")
+
     def python(self, *args: [str]):
         return subprocess.check_output([self.executable, *args]).decode()
 
@@ -41,12 +46,15 @@ class Venv:
 
     @property
     def pyconcrete_exe(self):
+        self.raise_if_pyconcrete_not_installed()
         return join(self.bin_dir, 'pyconcrete')
 
     def pyconcrete(self, *args: [str]):
+        self.raise_if_pyconcrete_not_installed()
         return subprocess.check_output([self.pyconcrete_exe, *args]).decode()
 
     def pyconcrete_cli(self, *args: [str]):
+        self.raise_if_pyconcrete_not_installed()
         cli_script = join(ROOT_DIR, 'pyecli')
         return subprocess.check_output([self.executable, cli_script, *args]).decode()
 

--- a/tests/exe_testcases/test_basic_raise_exception/expected.yaml
+++ b/tests/exe_testcases/test_basic_raise_exception/expected.yaml
@@ -1,0 +1,3 @@
+expected:
+  return_code: 1
+  is_ignore_stdout: True

--- a/tests/exe_testcases/test_basic_raise_exception/main.py
+++ b/tests/exe_testcases/test_basic_raise_exception/main.py
@@ -1,0 +1,1 @@
+raise Exception("Error")

--- a/tests/test_exe.py
+++ b/tests/test_exe.py
@@ -14,9 +14,9 @@
 import subprocess
 
 
-def test_exe__execute_an_non_exist_file(venv):
-    return_code = subprocess.check_call([venv.pyconcrete_exe, 'non_existing_file.txt'])
-    assert return_code == 0
+def test_exe__execute_an_non_exist_file(venv, pye_cli):
+    return_code = subprocess.call([venv.pyconcrete_exe, 'non_existing_file.txt'])
+    assert return_code == 1
 
 
 def test_exe__sys_path__should_contain_pye_file_dir(venv, pye_cli, tmpdir):


### PR DESCRIPTION
If the script raise exception at run time. pyconcrete-exe should exit and return non-zero return code.