### PR TITLE
fix(meson): add building dependency for secret_key.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,7 @@ ext_includes = [
     './src/pyconcrete_ext/openaes/inc/',
 ]
 ext_srcs = [
+    gen_secret_key,  # make sure building dependency
     './src/pyconcrete_ext/pyconcrete.c',
     './src/pyconcrete_ext/pyconcrete_module.c',
     './src/pyconcrete_ext/openaes/src/oaes_base64.c',
@@ -91,6 +92,7 @@ exe_includes = [
     './src/pyconcrete_ext/openaes/inc/',
 ]
 exe_srcs = [
+    gen_secret_key,  # make sure building dependency
     './src/pyconcrete_exe/pyconcrete_exe.c',
     './src/pyconcrete_ext/pyconcrete.c',
     './src/pyconcrete_ext/openaes/src/oaes_base64.c',


### PR DESCRIPTION
## Background
Fix issue #117 
The building order may not as expected. 

## Solution
Follow meson doc, the header file should be added into sources list.
[Meson Doc - Generating headers](https://mesonbuild.com/Generating-sources.html#generating-headers)