### PR TITLE
fix: issue 124 unicode sys.argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Pyconcrete Changelog
 
+## 1.1.? (????)
+
+### Bug fixes
+* Add `__file__` for entry pye script https://github.com/Falldog/pyconcrete/issues/123
+* Fix `sys.argv` to support unicode https://github.com/Falldog/pyconcrete/issues/124
+  * Python 3.7 on Windows is not support
+
+### Breaking Changes
+* Default enable Python utf8 mode, ref doc: https://docs.python.org/3/library/os.html#utf8-mode
+
+
 ## 1.1.0 (2025-07-24)
 
 ### Features

--- a/src/pyconcrete_exe/pyconcrete_exe.c
+++ b/src/pyconcrete_exe/pyconcrete_exe.c
@@ -27,6 +27,10 @@ PyObject* getFullPath(const char* filepath);
 
 int main(int argc, char *argv[])
 {
+
+// https://docs.python.org/3/c-api/init_config.html#init-config
+// Since Python 3.8, it's recommended to use PyConfig to do initialization
+// But for support Python 3.7, we will apply it in future
 #if PY_MAJOR_VERSION >= 3
     int i, len;
     int ret = RET_OK;
@@ -34,10 +38,11 @@ int main(int argc, char *argv[])
     argv_ex = (wchar_t**) malloc(sizeof(wchar_t*) * argc);
     for(i=0 ; i<argc ; ++i)
     {
-        len = mbstowcs(NULL, argv[i], 0);
-        argv_ex[i] = (wchar_t*) malloc(sizeof(wchar_t) * (len+1));
-        mbstowcs(argv_ex[i], argv[i], len);
-        argv_ex[i][len] = 0;
+        argv_ex[i] = Py_DecodeLocale(argv[i], NULL);
+        if (!argv_ex[i]) {
+            fprintf(stderr, "Error, cannot decode argv[%d]\n", i);
+            return RET_FAIL;
+        }
     }
 #else
     char** argv_ex = argv;
@@ -95,7 +100,7 @@ int main(int argc, char *argv[])
 #if PY_MAJOR_VERSION >= 3
     for(i=0 ; i<argc ; ++i)
     {
-        free(argv_ex[i]);
+        PyMem_RawFree(argv_ex[i]);
     }
     free(argv_ex);
 #endif

--- a/src/pyconcrete_exe/pyconcrete_exe.c
+++ b/src/pyconcrete_exe/pyconcrete_exe.c
@@ -311,7 +311,8 @@ int prependSysPath0(const _CHAR* script_path)
     PyObject* py_script_path = getFullPath(script_path);
     PyObject* path_module = PyImport_ImportModule("os.path");
     PyObject* dirname_func = PyObject_GetAttrString(path_module, "dirname");
-    PyObject* script_dir = PyObject_CallOneArg(dirname_func, py_script_path);
+    PyObject* args = Py_BuildValue("(O)", py_script_path);
+    PyObject* script_dir = PyObject_CallObject(dirname_func, args);
 
     PyObject* sys_path = PySys_GetObject("path");
     if (PyList_Insert(sys_path, 0, script_dir) < 0) {
@@ -321,6 +322,7 @@ int prependSysPath0(const _CHAR* script_path)
     Py_XDECREF(py_script_path);
     Py_XDECREF(path_module);
     Py_XDECREF(dirname_func);
+    Py_XDECREF(args);
     Py_XDECREF(script_dir);
     return ret;
 }
@@ -333,10 +335,12 @@ PyObject* getFullPath(const _CHAR* filepath)
     PyObject* path_module = PyImport_ImportModule("os.path");
     PyObject* abspath_func = PyObject_GetAttrString(path_module, "abspath");
     PyObject* py_filepath = _PyUnicode_FromStringAndSize(filepath, _strlen(filepath));
-    PyObject* py_file_abspath = PyObject_CallOneArg(abspath_func, py_filepath);
+    PyObject* args = Py_BuildValue("(O)", py_filepath);
+    PyObject* py_file_abspath = PyObject_CallObject(abspath_func, args);
 
     Py_XDECREF(path_module);
     Py_XDECREF(abspath_func);
     Py_XDECREF(py_filepath);
+    Py_XDECREF(args);
     return py_file_abspath;
 }

--- a/tests/test_exe.py
+++ b/tests/test_exe.py
@@ -85,6 +85,27 @@ print(" ".join(sys.argv))
     assert output == f'{pye_path} -a -b -c'
 
 
+def test_exe__sys_argv__in_unicode(venv_exe, pye_cli, tmpdir):
+    # prepare
+    pye_path = (
+        pye_cli.setup(tmpdir, 'test_sys_argv')
+        .source_code(
+            """
+import sys
+print(" ".join(sys.argv))
+            """.strip()
+        )
+        .get_encrypt_path()
+    )
+
+    # execution
+    output = venv_exe.pyconcrete(pye_path, '早安', '=', 'おはようございます')
+    output = output.strip()
+
+    # verification
+    assert output == f'{pye_path} 早安 = おはようございます'
+
+
 def test_exe__import_pyconcrete__venv_exe__validate__file__(venv_exe, pye_cli, tmpdir):
     """
     compare to test_lib__import_pyconcrete__venv_lib__validate__file__

--- a/tests/test_exe.py
+++ b/tests/test_exe.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os.path
+import platform
 import subprocess
+import sys
+
+import pytest
 
 
 def test_exe__execute_an_non_exist_file(venv_exe):
@@ -85,6 +89,7 @@ print(" ".join(sys.argv))
     assert output == f'{pye_path} -a -b -c'
 
 
+@pytest.mark.skipif(platform.system() == 'Windows' and sys.version_info < (3, 8), reason="Windows requires python3.8")
 def test_exe__sys_argv__in_unicode(venv_exe, pye_cli, tmpdir):
     # prepare
     pye_path = (


### PR DESCRIPTION
# Background
Fix #124 
`sys.argv` should support unicode string as argumnet

# Solution
* Python 3.7 stay in original behavior
* Python 3.8+ use PyPreConfig & PyConfig to setup argv
* pyconcrete_exe.c use `wmain` on Windows platform
* pyconcrete_exe.c use `main` on other platform
  * for supporting wmain & main in code, use macro define custom `_XXXX` to support it at the same logic
* (Breaking Change) for Python 3.8+, enable utf8_mode by PyPreConfig, ref doc: https://docs.python.org/3/library/os.html#utf8-mode

# Not support platform
Windows Python3.7