### PR TITLE
fix(loader): Fix #130, FileFinder remove to handle default suffix

### DIFF
--- a/src/pyconcrete/__init__.py
+++ b/src/pyconcrete/__init__.py
@@ -103,7 +103,8 @@ class PyeLoader(SourceFileLoader):
 
 
 def install():
-    loader_details = [(PyeLoader, SOURCE_SUFFIXES)] + _get_supported_file_loaders()
+    # only put pyconcrete ext/suffix(.pye) for loader, leave default suffixes(SOURCE_SUFFIXES) to default loader
+    loader_details = [(PyeLoader, [get_ext()])] + _get_supported_file_loaders()
 
     sys.path_importer_cache.clear()
     sys.path_hooks.insert(0, FileFinder.path_hook(*loader_details))


### PR DESCRIPTION
Issue #130 

## Why
PyeLoader import `av` module will got exception 

## How
Doesn't need to handle default suffixes (`SOURCE_SUFFIXES`) behavior in `PyeLoader`, skip it